### PR TITLE
removed gulp-bundle from package.json as it is no longer needed, updated...

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -98,7 +98,9 @@ gulp.task('clean', function () {
 });
 
 // Bundle
-gulp.task('bundle', [<% if (includeSass) { %>'styles', <% } %>'scripts', 'bower'], $.bundle('./app/*.html'));
+gulp.task('bundle', [<% if (includeSass) { %>'styles', <% } %>'scripts', 'bower'], function(){
+    return gulp.src('./app/*.html');
+});
 
 // Build
 gulp.task('build', ['html', 'bundle', 'images']);

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -17,9 +17,8 @@
     "gulp-ruby-sass": "~0.3.0",<% } %>
     "gulp-connect": "~1.0.0",<% if (includeJade) { %>
     "gulp-jade": "~0.4.2",<% } %>
-    "gulp-useref": "~0.1.2",<% if (includeCoffeeScript) { %>
+    "gulp-useref": "~0.4.4",<% if (includeCoffeeScript) { %>
     "gulp-coffee": "~1.4.1",<% } %>
-    "gulp-bundle": "~0.2.0",
     "gulp-browserify": "~0.4.6",
     "reactify": "~0.10.0"
   },


### PR DESCRIPTION
... gulp-useref version. Refactored gulpfile.js because of the removal of gulp-bundle.

in my project also there was an error in the main.scss file, where the bootstrap path was wrong but it seems to be correct in the generator, idk why it was changed for me.
