### PR TITLE
index.html: removed duplicated react.js include

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,7 +11,6 @@
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
         <link rel="stylesheet" href="styles/main.css">
-        <script src="http://fb.me/react-0.9.0.min.js"></script>
         <% if (includeModernizr) { %>
         <!-- build:js scripts/vendor/modernizr.js -->
         <script src="bower_components/modernizr/modernizr.js"></script>


### PR DESCRIPTION
It is already included by app.js, so the <script> tag in index.html is redundant.
