### PR TITLE
WIP: drop bower task

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -3,9 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "~2.1.0",
-    "react": "^0.10.0",
     "bootstrap-sass-official": "^3.1.1",
     "modernizr": "^2.8.3"
   }
 }
-

--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -88,7 +88,7 @@ gulp.task('clean', function () {
 
 
 // Bundle
-gulp.task('bundle', [<% if (includeSass) { %>'styles', <% } %>'scripts', 'bower'], function(){
+gulp.task('bundle', [<% if (includeSass) { %>'styles', <% } %>'scripts'], function(){
     return gulp.src('./app/*.html')
                .pipe($.useref.assets())
                .pipe($.useref.restore())
@@ -110,13 +110,6 @@ gulp.task('connect', $.connect.server({
     port: 9000,
     livereload: true
 }));
-
-// Bower helper
-gulp.task('bower', function() {
-    gulp.src('app/bower_components/**/*.js', {base: 'app/bower_components'})
-        .pipe(gulp.dest('dist/bower_components/'));
-
-});
 
 gulp.task('json', function() {
     gulp.src('app/scripts/json/**/*.json', {base: 'app/scripts'})


### PR DESCRIPTION
Hiya! This is a work in progress PR about how the bower task works. Probably almost all of bower_components is unnecessary in dist, but I guess the usecase for this is to make assets like the bootstrap glyph font available? Could there be some cleaner method for this I wonder?

Also this change would drop the React bower dep since I guess there are no assets there to load?

Thanks for a great generator btw, two sales PoCs down and many more to come :D
