### PR TITLE
Run Clean Task Synchronously

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -106,7 +106,7 @@ gulp.task('jest', function () {
 
 // Clean
 gulp.task('clean', function (cb) {
-    del(['dist/styles', 'dist/scripts', 'dist/images'], cb);
+    cb(del.sync(['dist/styles', 'dist/scripts', 'dist/images']));
 });
 
 


### PR DESCRIPTION
Run clean task synchronously to ensure that it completes before the build task starts.