### PR TITLE
Use gulp.watch to watch *.js files instead of watchify

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -10,7 +10,6 @@ var path = require('path');
 // Load plugins
 var $ = require('gulp-load-plugins')();
 var browserify = require('browserify');
-var watchify = require('watchify');
 var source = require('vinyl-source-stream'),
     <% if (includeCoffeeScript) { %>
     sourceFile = './app/scripts/app.coffee',
@@ -37,26 +36,17 @@ gulp.task('styles', function () {
 
 // Scripts
 gulp.task('scripts', function () {
-    var bundler = watchify(browserify({
+    return browserify({
         entries: [sourceFile],
         insertGlobals: true,
         cache: {},
         packageCache: {},
         fullPaths: true
-    }));
-
-    bundler.on('update', rebundle);
-
-    function rebundle() {
-        return bundler.bundle()
-            // log errors if they happen
-            .on('error', $.util.log.bind($.util, 'Browserify Error'))
-            .pipe(source(destFileName))
-            .pipe(gulp.dest(destFolder));
-    }
-
-    return rebundle();
-
+    }).bundle()
+    // log errors if they happen
+    .on('error', $.util.log.bind($.util, 'Browserify Error'))
+    .pipe(source(destFileName))
+    .pipe(gulp.dest(destFolder));
 });
 
 
@@ -149,6 +139,13 @@ gulp.task('extras', function () {
 
 // Watch
 gulp.task('watch', ['html', 'bundle', 'serve'], function () {
+    <% if (includeCoffeeScript) { %>
+        // Watch .coffee files
+        gulp.watch('app/scripts/**/*.coffee', ['scripts']);
+    <% } else { %>
+        // Watch .js files
+        gulp.watch('app/scripts/**/*.js', ['scripts']);
+    <% } %>
 
     // Watch .json files
     gulp.watch('app/scripts/**/*.json', ['json']);

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -22,7 +22,6 @@
     "jest": "latest",<% } %>
     "react": "latest",
     "reactify": "latest",
-    "watchify": "~2.1",
     "browserify-shim": "^3.8.0",
     "vinyl-source-stream": "^1.0.0"
   },


### PR DESCRIPTION
Hey!

Are there any particular reasons you use `watchify` over `gulp.watch`? At least the way it's done now leads to `scripts` task to never terminate, which is not ideal for dependent tasks like `build`. It just hangs there in the terminal. Not the biggest problem in the world, nor a good behavior either. I want my build to terminate eventually =)

In this PR i switched to `gulp.watch` over `watchify`. But if the use of `watchify` is necessary for a reason, we could find another way to implement it the way it would not hang dependent tasks.