### PR TITLE
Fix bug that looks for fonts in absolute path

### DIFF
--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,4 +1,4 @@
-<% if (includeBootstrap) { %>$icon-font-path: "/fonts/";
+<% if (includeBootstrap) { %>$icon-font-path: "../fonts/";
 
 @import "bootstrap-sass-official/assets/stylesheets/bootstrap";
 


### PR DESCRIPTION
When you push `dist` to a Github page, fonts don't render correctly because browser is looking for an absolute path. Using a relative path fixes this.