### PR TITLE
Adding bower_components to .gitignore

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .sass-cache/
+bower_components/


### PR DESCRIPTION
Adds bower_components/ to .gitignore to prevent large, accidental commits.