### PR TITLE
fix syntax on .gitignore for root directories

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,4 +1,4 @@
-node_modules/
-dist/
+/node_modules/
+/dist/
 .sass-cache/
-bower_components/
+/bower_components/


### PR DESCRIPTION
After looking at the latest in the repo and seeing that 'bower_components/' is included in the default .gitignore, this pull request is a bit redundant, but I got burned pretty badly, so I thought I would still go ahead and share what I found (seems like the web is 50/50 split on whether ignoring bower_components is correct, so it's still somewhat valid).

After working on my generated app for a bit, I committed everything to a git repository and continued working. When I got to the point that I wanted to share, I wrote up a quick readme and did a fresh pull to ensure I could get from nothing to running the app with a few commands. I wound up hitting some nasty errors which ultimately boiled down to the fact that /app/bower_components/jquery/dist was missing from my repo, but that there was a dependency on it from index.html.

This was ultimately attributed to the fact that the .gitignore generated by the template is configured to ignore *any* 'dist' directory, including those deep in the bower_components, rather than the intent, which is to ignore the 'dist' directory at the root (e.g. /dist/).

So the .gitignore was causing me to only partially commit the bower_components which, of course, a fresh 'bower install' didn't catch as it saw all the components there.

The pull request simply updates the .gitignore template to correcty refer to only the top level directories.