### PR TITLE
Improved support for generator options

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -23,7 +23,7 @@ var ReactGulpBrowserifyGenerator = yeoman.generators.Base.extend({
         console.log(this.yeoman);
 
         // replace it with a short and sweet description of your generator
-        console.log(chalk.magenta('You\'re using the fantastic React generator. We provide you full JavaScript solution with Sass support!'));
+        console.log(chalk.magenta('You\'re using the fantastic React generator. We provide you full JavaScript solution with Sass or Stylus support!'));
 
         var prompts = [{
             name: 'project',
@@ -96,9 +96,22 @@ var ReactGulpBrowserifyGenerator = yeoman.generators.Base.extend({
         this.mkdir('app/images');
 
         this.template('_package.json', 'package.json');
-        this.template('_gulpfile.js', 'gulpfile.js');
         this.template('_bower.json', 'bower.json');
-        this.template('main.scss', 'app/styles/main.scss');
+
+        if (this.includeCoffeeScript) {
+            this.template('_gulpfile-coffee.js', 'gulpfile.js');
+            this.template('_gulpfile.coffee', 'gulpfile.coffee');
+        } else {
+            this.template('_gulpfile.js', 'gulpfile.js');
+        }
+
+        if (this.includeSass) {
+            this.template('main.scss', 'app/styles/main.scss');
+        } else if (this.includeStylus) {
+            this.template('main.styl', 'app/styles/main.styl');
+        } else {
+            this.template('main.css', 'app/styles/main.css');
+        }
 
         this.copy('index.html', 'app/index.html');
 

--- a/app/index.js
+++ b/app/index.js
@@ -42,6 +42,10 @@ var ReactGulpBrowserifyGenerator = yeoman.generators.Base.extend({
                 value: 'includeStylus',
                 checked: false
             }, {
+                name: 'jQuery',
+                value: 'includejQuery',
+                checked: true
+            }, {
                 name: 'Bootstrap',
                 value: 'includeBootstrap',
                 checked: true
@@ -75,6 +79,7 @@ var ReactGulpBrowserifyGenerator = yeoman.generators.Base.extend({
             // we change a bit this way of doing to automatically do this in the self.prompt() method.
             this.includeSass = hasFeature('includeSass');
             this.includeStylus = hasFeature('includeStylus');
+            this.includejQuery = hasFeature('includejQuery');
             this.includeBootstrap = hasFeature('includeBootstrap');
             this.includeModernizr = hasFeature('includeModernizr');
             this.includeJade = hasFeature('includeJade');
@@ -113,7 +118,11 @@ var ReactGulpBrowserifyGenerator = yeoman.generators.Base.extend({
             this.template('main.css', 'app/styles/main.css');
         }
 
-        this.copy('index.html', 'app/index.html');
+        if (this.includeJade) {
+            this.template('index.jade', 'app/index.jade');
+        } else {
+            this.template('index.html', 'app/index.html');
+        }
 
         if (this.includeCoffeeScript) {
             this.copy('app.coffee', 'app/scripts/app.coffee');

--- a/app/index.js
+++ b/app/index.js
@@ -119,7 +119,7 @@ var ReactGulpBrowserifyGenerator = yeoman.generators.Base.extend({
         }
 
         if (this.includeJade) {
-            this.template('index.jade', 'app/index.jade');
+            this.template('index.jade', 'app/template/index.jade');
         } else {
             this.template('index.html', 'app/index.html');
         }

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -1,10 +1,11 @@
 {
   "name": "<%= _.slugify(projectName) %>",
   "version": "0.0.1",
-  "dependencies": {<% if (includeBootstrap) { %>
-    "jquery": "~2.1.1",<% } if (includeBootstrap && includeSass) { %>
+  "dependencies": {<% if (includeBootstrap || includejQuery) { %>
+    "jquery": "~2.1.1",<% } if (includeBootstrap && (!includeSass && !includeStylus)) { %>
+    "bootstrap": ">=3.3.5", <% } if (includeBootstrap && includeSass) { %>
     "bootstrap-sass-official": ">=3.3.0",<% } if (includeBootstrap && includeStylus) { %>
-    "bootstrap-stylus": ">=4.0.5",<%} if (includeModernizer) { %>
+    "bootstrap-stylus": ">=4.0.5",<% } if (includeModernizr) { %>
     "modernizr": "^2.8.3"<% } %>
   }
 }

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -2,10 +2,10 @@
   "name": "<%= _.slugify(projectName) %>",
   "version": "0.0.1",
   "dependencies": {<% if (includeBootstrap || includejQuery) { %>
-    "jquery": "~2.1.1",<% } if (includeBootstrap && (!includeSass && !includeStylus)) { %>
-    "bootstrap": ">=3.3.5", <% } if (includeBootstrap && includeSass) { %>
-    "bootstrap-sass-official": ">=3.3.0",<% } if (includeBootstrap && includeStylus) { %>
-    "bootstrap-stylus": ">=4.0.5",<% } if (includeModernizr) { %>
+    "jquery": "~2.1.1"<% if (includeBootstrap || includeModernizr) { %>,<% } } if (includeBootstrap && (!includeSass && !includeStylus)) { %>
+    "bootstrap": ">=3.3.5"<% if (includeModernizr) { %>,<% } } if (includeBootstrap && includeSass) { %>
+    "bootstrap-sass-official": ">=3.3.0"<% if (includeModernizr) { %>,<% } } if (includeBootstrap && includeStylus) { %>
+    "bootstrap-stylus": ">=4.0.5"<% if (includeModernizr) { %>,<% } } if (includeModernizr) { %>
     "modernizr": "^2.8.3"<% } %>
   }
 }

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -1,9 +1,10 @@
 {
   "name": "<%= _.slugify(projectName) %>",
   "version": "0.0.1",
-  "dependencies": {
-    "jquery": "~2.1.1",
-    "bootstrap-sass-official": ">=3.3.0",
-    "modernizr": "^2.8.3"
+  "dependencies": {<% if (includeBootstrap) { %>
+    "jquery": "~2.1.1",<% } if (includeBootstrap && includeSass) { %>
+    "bootstrap-sass-official": ">=3.3.0",<% } if (includeBootstrap && includeStylus) { %>
+    "bootstrap-stylus": ">=4.0.5",<%} if (includeModernizer) { %>
+    "modernizr": "^2.8.3"<% } %>
   }
 }

--- a/app/templates/_gulpfile-coffee.js
+++ b/app/templates/_gulpfile-coffee.js
@@ -1,0 +1,2 @@
+require("coffee-script/register");
+require("./gulpfile.coffee");

--- a/app/templates/_gulpfile.coffee
+++ b/app/templates/_gulpfile.coffee
@@ -1,0 +1,202 @@
+rebundle = ->
+  bundler.bundle().on("error", $.util.log.bind($.util, "Browserify Error")).pipe(source(destFileName)).pipe(gulp.dest(destFolder)).on "end", ->
+    reload()
+
+"use strict"
+gulp = require("gulp")
+del = require("del")
+<% if (includeJest) { %>path = require("path")<% } %>
+
+# Load plugins
+
+$ = require("gulp-load-plugins")()
+browserify = require("browserify")
+watchify = require("watchify")
+source = require("vinyl-source-stream")
+sourceFile = "./app/scripts/app.coffee"
+destFolder = "./dist/scripts"
+destFileName = "app.js"
+browserSync = require("browser-sync")
+reload = browserSync.reload
+
+# Styles
+
+gulp.task "styles", [
+ <% if (includeSass) { %> "sass"<% } %>
+ <% if (includeStylus) { %> "stylus"<% } %>
+  "moveCss"
+]
+
+gulp.task "moveCss", [ "clean" ], ->
+  # the base option sets the relative root for the set of files,
+  # preserving the folder structure
+  gulp.src([ "./app/styles/**/*.css" ], base: "./app/styles/").pipe gulp.dest("dist/styles")
+
+<% if (includeSass) { %>
+gulp.task "sass", ->
+  $.rubySass("./app/styles",
+    style: "expanded"
+    precision: 10
+    loadPath: [ "app/bower_components" ]).pipe($.autoprefixer("last 1 version")).pipe(gulp.dest("dist/styles")).pipe $.size()
+<% } if (includeStylus) { %>
+
+gulp.task "stylus", ->
+  gulp.src([ "app/styles/**/*.styl" ]).pipe($.stylus()).pipe($.autoprefixer("last 1 version")).pipe(gulp.dest("dist/styles")).pipe $.size()
+
+<% } %>
+
+bundler = watchify(browserify(
+  entries: [ sourceFile ]
+  debug: true
+  insertGlobals: true
+  cache: {}
+  packageCache: {}
+  fullPaths: true))
+
+bundler.on "update", rebundle
+bundler.on "log", $.util.log
+
+# Scripts
+
+gulp.task "scripts", rebundle
+
+gulp.task "buildScripts", ->
+  browserify(sourceFile).bundle().pipe(source(destFileName)).pipe gulp.dest("dist/scripts")
+
+<% if (includeJade) { %>
+
+gulp.task "jade", ->
+  gulp.src("app/template/*.jade").pipe($.jade(pretty: true)).pipe gulp.dest("dist")
+
+<% } %>
+
+# HTML
+
+gulp.task "html", ->
+  gulp.src("app/*.html").pipe($.useref()).pipe(gulp.dest("dist")).pipe $.size()
+
+# Images
+
+gulp.task "images", ->
+  gulp.src("app/images/**/*").pipe($.cache($.imagemin(
+    optimizationLevel: 3
+    progressive: true
+    interlaced: true))).pipe(gulp.dest("dist/images")).pipe $.size()
+
+# Fonts
+
+gulp.task "fonts", ->
+  gulp.src(require("main-bower-files")(filter: "**/*.{eot,svg,ttf,woff,woff2}").concat("app/fonts/**/*")).pipe gulp.dest("dist/fonts")
+
+# Clean
+
+gulp.task "clean", (cb) ->
+  $.cache.clearAll()
+  cb del.sync([
+    "dist/styles"
+    "dist/scripts"
+    "dist/images"
+  ])
+
+# Bundle
+
+gulp.task "bundle", [
+  "styles"
+  "scripts"
+  "bower"
+], ->
+  gulp.src("./app/*.html").pipe($.useref.assets()).pipe($.useref.restore()).pipe($.useref()).pipe gulp.dest("dist")
+
+gulp.task "buildBundle", [
+  "styles"
+  "buildScripts"
+  "moveLibraries"
+  "bower"
+], ->
+  gulp.src("./app/*.html").pipe($.useref.assets()).pipe($.useref.restore()).pipe($.useref()).pipe gulp.dest("dist")
+
+# Move JS Files and Libraries
+
+gulp.task "moveLibraries", [ "clean" ], ->
+  # the base option sets the relative root for the set of files,
+  # preserving the folder structure
+  gulp.src([ "./app/scripts/**/*.js" ], base: "./app/scripts/").pipe gulp.dest("dist/scripts")
+
+# Bower helper
+
+gulp.task "bower", ->
+  gulp.src("app/bower_components/**/*.js", base: "app/bower_components").pipe gulp.dest("dist/bower_components/")
+
+gulp.task "json", ->
+  gulp.src("app/scripts/json/**/*.json", base: "app/scripts").pipe gulp.dest("dist/scripts/")
+
+# Robots.txt and favicon.ico
+
+gulp.task "extras", ->
+  gulp.src([
+    "app/*.txt"
+    "app/*.ico"
+  ]).pipe(gulp.dest("dist/")).pipe $.size()
+
+# Watch
+
+gulp.task "watch", [
+  "html"
+  "fonts"
+  "bundle"
+], ->
+  browserSync
+    notify: false
+    logPrefix: "BS"
+    server: [
+      "dist"
+      "app"
+    ]
+  
+  # Watch .json files
+  
+  gulp.watch "app/scripts/**/*.json", [ "json" ]
+  
+  # Watch .html files
+  
+  gulp.watch "app/*.html", [ "html" ]
+  gulp.watch [
+    "app/styles/**/*.scss"
+    "app/styles/**/*.css"
+    "app/styles/*.styl"
+  ], [
+    "styles"
+    "scripts"
+    reload
+  ]
+  <% if (includeJade) { %>
+  # Watch .jade files
+
+  gulp.watch "app/template/**/*.jade", [
+    "jade"
+    "html"
+    reload
+  ]
+  <% } %>
+  # Watch image files
+
+  gulp.watch "app/images/**/*", reload
+
+# Build
+
+gulp.task "build", [
+  "html"
+  "buildBundle"
+  "images"
+  "fonts"
+  "extras"
+], ->
+  gulp.src("dist/scripts/app.js").pipe($.uglify()).pipe($.stripDebug()).pipe gulp.dest("dist/scripts")
+
+# Default task
+
+gulp.task "default", [
+  "clean"
+  "build"
+  "jest"
+]

--- a/app/templates/_gulpfile.coffee
+++ b/app/templates/_gulpfile.coffee
@@ -37,7 +37,7 @@ gulp.task "sass", ->
   $.rubySass("./app/styles",
     style: "expanded"
     precision: 10
-    loadPath: [ "app/bower_components" ]).pipe($.autoprefixer("last 1 version")).pipe(gulp.dest("dist/styles")).pipe $.size()
+    <% if (includeBootstrap || includejQuery || includeModernizr) { %>loadPath: [ "app/bower_components" ]).pipe($.autoprefixer("last 1 version")).pipe(gulp.dest("dist/styles")).pipe $.size()<% } %>
 <% } if (includeStylus) { %>
 
 gulp.task "stylus", ->
@@ -86,7 +86,9 @@ gulp.task "images", ->
 # Fonts
 
 gulp.task "fonts", ->
+  <% if (includeBootstrap || includejQuery || includeModernizr) { %>
   gulp.src(require("main-bower-files")(filter: "**/*.{eot,svg,ttf,woff,woff2}").concat("app/fonts/**/*")).pipe gulp.dest("dist/fonts")
+  <% } %>
 
 # Clean
 
@@ -125,7 +127,7 @@ gulp.task "moveLibraries", [ "clean" ], ->
 # Bower helper
 
 gulp.task "bower", ->
-  gulp.src("app/bower_components/**/*.js", base: "app/bower_components").pipe gulp.dest("dist/bower_components/")
+  <% if (includeBootstrap || includejQuery || includeModernizr) { %>gulp.src("app/bower_components/**/*.js", base: "app/bower_components").pipe gulp.dest("dist/bower_components/")<% } %>
 
 gulp.task "json", ->
   gulp.src("app/scripts/json/**/*.json", base: "app/scripts").pipe gulp.dest("dist/scripts/")
@@ -141,7 +143,9 @@ gulp.task "extras", ->
 # Watch
 
 gulp.task "watch", [
+  <% if (includeJade) { %>"jade"<% } else { %>
   "html"
+  <% } %>
   "fonts"
   "bundle"
 ], ->
@@ -198,5 +202,5 @@ gulp.task "build", [
 gulp.task "default", [
   "clean"
   "build"
-  "jest"
+  <% if (includeJest) { %>"jest"<% } %>
 ]

--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -24,7 +24,7 @@ var browserSync = require('browser-sync');
 var reload = browserSync.reload;
 
 // Styles
-gulp.task('styles', ['sass', 'moveCss' <% if (includeStylus) { %> , 'stylus' <% } %> ]);
+gulp.task('styles', [<% if (includeSass) { %>'sass', <% } %>'moveCss'<% if (includeStylus) { %>, 'stylus' <% } %>]);
 
 gulp.task('moveCss',['clean'], function(){
   // the base option sets the relative root for the set of files,
@@ -32,18 +32,18 @@ gulp.task('moveCss',['clean'], function(){
   gulp.src(['./app/styles/**/*.css'], { base: './app/styles/' })
   .pipe(gulp.dest('dist/styles'));
 });
-
+<% if (includeSass) { %>
 gulp.task('sass', function() {
     return $.rubySass('./app/styles', {
             style: 'expanded',
-            precision: 10,
-            loadPath: ['app/bower_components']
+            precision: 10<% if (includeBootstrap || includejQuery || includeModernizr) { %>,
+            loadPath: ['app/bower_components']<% } %>
         })
         .pipe($.autoprefixer('last 1 version'))
         .pipe(gulp.dest('dist/styles'))
         .pipe($.size());
 });
-
+<% } %>
 <% if (includeStylus) { %>
 
 gulp.task('stylus', function() {
@@ -124,10 +124,12 @@ gulp.task('images', function() {
 
 // Fonts
 gulp.task('fonts', function() {
+    <% if (includeBootstrap || includejQuery || includeModernizr) { %>
     return gulp.src(require('main-bower-files')({
             filter: '**/*.{eot,svg,ttf,woff,woff2}'
         }).concat('app/fonts/**/*'))
         .pipe(gulp.dest('dist/fonts'));
+    <% } %>
 });
 
 // Clean
@@ -164,10 +166,10 @@ gulp.task('moveLibraries',['clean'], function(){
 
 // Bower helper
 gulp.task('bower', function() {
-    gulp.src('app/bower_components/**/*.js', {
+    <% if (includeBootstrap || includejQuery || includeModernizr) { %>gulp.src('app/bower_components/**/*.js', {
             base: 'app/bower_components'
         })
-        .pipe(gulp.dest('dist/bower_components/'));
+        .pipe(gulp.dest('dist/bower_components/'));<% } %>
 
 });
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -3,6 +3,7 @@
     "version": "0.0.0",
     "dependencies": {},
     "devDependencies": {
+        "browserify": "latest",
         "del": "~0.1.3",
         "gulp": "~3.8.8",
         "gulp-autoprefixer": "~1.0.1",
@@ -24,6 +25,7 @@
         "gulp-webserver": "latest", <% if (includeJest) { %>
         "jest-cli": "latest", <% } %>
         "react": "latest",
+        "react-dom": "latest",
         "react-tools": "latest",
         "reactify": "latest",
         "watchify": "~2.1",

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -5,7 +5,7 @@
     "devDependencies": {
         "browserify": "latest",
         "del": "~0.1.3",
-        "gulp": "~3.8.8",
+        "gulp": ">=3.8.8",
         "gulp-autoprefixer": "~1.0.1",
         "gulp-bower": "0.0.6",
         "gulp-cache": "~0.2.4", <% if (includeCoffeeScript) { %>

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -8,7 +8,8 @@
         "gulp-autoprefixer": "~1.0.1",
         "gulp-bower": "0.0.6",
         "gulp-cache": "~0.2.4", <% if (includeCoffeeScript) { %>
-        "coffeeify": "latest", <% } %>
+        "coffeeify": "latest",
+        "coffee-script": "latest", <% } %>
         "gulp-imagemin": "latest", <% if (includeJade) { %>
         "gulp-jade": "~0.8.0", <% } %> <% if (includeJest) { %>
         "gulp-jest": "~0.2.2", <% } %>

--- a/app/templates/app.coffee
+++ b/app/templates/app.coffee
@@ -1,4 +1,5 @@
 React = window.React = require("react")
+ReactDOM = require("react-dom")
 Timer = require("./ui/Timer.coffee")
 mountNode = document.getElementById("app")
 TodoList = React.createClass(
@@ -39,4 +40,4 @@ TodoApp = React.createClass(
       value: @state.text
     ), React.createElement("button", null, "Add #" + (@state.items.length + 1))), React.createElement(Timer, null)
 )
-React.render React.createElement(TodoApp, null), mountNode
+ReactDOM.render React.createElement(TodoApp, null), mountNode

--- a/app/templates/app.js
+++ b/app/templates/app.js
@@ -1,5 +1,6 @@
 
 var React = window.React = require('react'),
+    ReactDOM = require("react-dom"),
     Timer = require("./ui/Timer"),
     mountNode = document.getElementById("app");
 
@@ -40,5 +41,5 @@ var TodoApp = React.createClass({
 });
 
 
-React.render(<TodoApp />, mountNode);
+ReactDOM.render(<TodoApp />, mountNode);
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -48,8 +48,20 @@
                     <p>Compass is an open-source CSS Authoring Framework that uses Sass.</p>
                     <% } %>
 
-                    <h4>Bootstrap</h4>
+                    <% if (includeStylus) { %><h4>Stylus</h4>
+                    <p>Expressive, dynamic, robust CSS</p>
+                    <% } %>
+
+                    <% if (includeCoffeeScript) { %><h4>CoffeeScript</h4>
+                    <p>A little language that compiles into JavaScript</p>
+                    <% } %>
+
+                    <h4>jQuery</h4>
+                    <p>The Write Less, Do More, JavaScript Library.</p>
+
+                    <% if (includeBootstrap) { %><h4>Bootstrap</h4>
                     <p>Sleek, intuitive, and powerful mobile first front-end framework for faster and easier web development.</p>
+                    <% } %>
 
                     <% if (includeModernizr) { %><h4>Modernizr</h4>
                     <p>Modernizr is an open-source JavaScript library that helps you build the next generation of HTML5 and CSS3-powered websites.</p>
@@ -70,14 +82,33 @@
           <ul>
             <li>HTML5 Boilerplate</li>
             <% if (includeSass) { %><li>Sass with Compass</li><% } %>
+            <% if (includeStylus) { %><li>Stylus</li><% } %>
             <% if (includeModernizr) { %><li>Modernizr</li><% } %>
+            <% if (includejQuery) { %><li>jQuery</li><% } %>
+            <% if (includeCoffeeScript) { %><li>CoffeeScript</li><% } %>
           </ul>
         </div>
         <% } %>
 
         <!-- build:js scripts/vendor.js -->
         <!-- bower:js -->
-        <script src="bower_components/jquery/dist/jquery.js"></script>
+        <% if (includeBootstrap || includejQuery) { %><script src="bower_components/jquery/dist/jquery.js"></script><% } %>
+        <% if (includeBootstrap && (!includeSass && !includeStylus)) { %>
+        <script src="bower_components/bootstrap/dist/js/bootstrap.min.js"></script><% } %>
+        <% if (includeSass && includeBootstrap) { %><script src="bower_components/bootstrap-sass/assets/javascripts/bootstrap.min.js"></script><% } %>
+        <% if (includeStylus && includeBootstrap) { %><script src="bower_components/bootstrap-stylus/js/transition.js"></script>
+        <script src="bower_components/bootstrap-stylus/js/alert.js"></script>
+        <script src="bower_components/bootstrap-stylus/js/button.js"></script>
+        <script src="bower_components/bootstrap-stylus/js/carousel.js"></script>
+        <script src="bower_components/bootstrap-stylus/js/collapse.js"></script>
+        <script src="bower_components/bootstrap-stylus/js/dropdown.js"></script>
+        <script src="bower_components/bootstrap-stylus/js/modal.js"></script>
+        <script src="bower_components/bootstrap-stylus/js/tooltip.js"></script>
+        <script src="bower_components/bootstrap-stylus/js/popover.js"></script>
+        <script src="bower_components/bootstrap-stylus/js/scrollspy.js"></script>
+        <script src="bower_components/bootstrap-stylus/js/tab.js"></script>
+        <script src="bower_components/bootstrap-stylus/js/affix.js"></script>
+        <% } %>
         <!-- endbower -->
         <!-- endbuild -->
         <script src="scripts/app.js"></script>

--- a/app/templates/index.jade
+++ b/app/templates/index.jade
@@ -1,16 +1,10 @@
 doctype html
-//if lt IE 7
-  html.no-js.lt-ie9.lt-ie8.lt-ie7  
-//if IE 7
-  html.no-js.lt-ie9.lt-ie8  
-//if IE 8
-  html.no-js.lt-ie9  
-// [if gt IE 8] <!
-html.no-js
-  // <![endif]
+
+html(lang="en")
+
   head
     meta(charset='utf-8')
-    title!=<%= appname %>
+    title <%= appname %>
     meta(name='description', content='')
     meta(name='viewport', content='width=device-width')
     // Place favicon.ico and apple-touch-icon.png in the root directory
@@ -38,7 +32,7 @@ html.no-js
             a(href='#') About
           li
             a(href='#') Contact
-        h3.text-muted!=<%= appname %>
+        h3.text-muted <%= appname %>
       #app.jumbotron
         h1 'Allo, 'Allo!
         p.lead Always a pleasure scaffolding your apps.
@@ -82,7 +76,7 @@ html.no-js
     // bower:js
     <% if (includeBootstrap || includejQuery) { %>script(src='bower_components/jquery/dist/jquery.js')<% } %>
     <% if (includeBootstrap && (!includeSass && !includeStylus)) { %>script(src='bower_components/bootstrap/dist/js/bootstrap.min.js')<% } %>
-    <% if (includeSass && includeBootstrap) { %>script(src='bower_components/bootstrap-sass/assets/javascripts/bootstrap.min.js')<% } %>
+    <% if (includeSass && includeBootstrap) { %>script(src='bower_components/bootstrap-sass-official/assets/javascripts/bootstrap.min.js')<% } %>
     <% if (includeStylus && includeBootstrap) { %>script(src='bower_components/bootstrap-stylus/js/transition.js')
     script(src='bower_components/bootstrap-stylus/js/alert.js')
     script(src='bower_components/bootstrap-stylus/js/button.js')

--- a/app/templates/index.jade
+++ b/app/templates/index.jade
@@ -1,0 +1,108 @@
+doctype html
+//if lt IE 7
+  html.no-js.lt-ie9.lt-ie8.lt-ie7  
+//if IE 7
+  html.no-js.lt-ie9.lt-ie8  
+//if IE 8
+  html.no-js.lt-ie9  
+// [if gt IE 8] <!
+html.no-js
+  // <![endif]
+  head
+    meta(charset='utf-8')
+    title!=<%= appname %>
+    meta(name='description', content='')
+    meta(name='viewport', content='width=device-width')
+    // Place favicon.ico and apple-touch-icon.png in the root directory
+    link(rel='stylesheet', href='styles/main.css')
+    <% if (includeModernizr) { %>
+    // build:js scripts/vendor/modernizr.js
+    script(src='bower_components/modernizr/modernizr.js')
+    // endbuild
+    <% } %>
+  body
+    //if lt IE 10
+      p.browsehappy
+        | You are using an 
+        strong outdated
+        |  browser. Please 
+        a(href='http://browsehappy.com/') upgrade your browser
+        |  to improve your experience.
+    <% if (includeBootstrap) { %>
+    .container
+      .header
+        ul.nav.nav-pills.pull-right
+          li.active
+            a(href='#') Home
+          li
+            a(href='#') About
+          li
+            a(href='#') Contact
+        h3.text-muted!=<%= appname %>
+      #app.jumbotron
+        h1 'Allo, 'Allo!
+        p.lead Always a pleasure scaffolding your apps.
+        p
+          a.btn.btn-lg.btn-success(href='#') Splendid!
+      #content.row.marketing
+        .col-lg-6
+          h4 HTML5 Boilerplate
+          p
+            | HTML5 Boilerplate is a professional front-end template for building fast, robust, and adaptable web apps or sites.
+          <% if (includeSass) { %>h4 Sass with Compass
+          p Compass is an open-source CSS Authoring Framework that uses Sass.<% } %>
+          <% if (includeStylus) { %>h4 Stylus
+          p Expressive, dynamic, robust CSS<% } %>
+          <% if (includeCoffeeScript) { %>h4 CoffeeScript
+          p A little language that compiles into JavaScript<% } %>
+          h4 jQuery
+          p The Write Less, Do More, JavaScript Library.
+          <% if (includeBootstrap) { %>h4 Bootstrap
+          p
+            | Sleek, intuitive, and powerful mobile first front-end framework for faster and easier web development.<% } %>
+          <% if (includeModernizr) { %>h4 Modernizr
+          p
+            | Modernizr is an open-source JavaScript library that helps you build the next generation of HTML5 and CSS3-powered websites.<% } %>
+      .footer
+        p ♥ from the Yeoman team
+    <% } else { %>
+    #app
+    .hero-unit
+      h1 'Allo, 'Allo!
+      p You now have
+      ul
+        li HTML5 Boilerplate
+        <% if (includeSass) { %>li Sass with Compass<% } %>
+        <% if (includeStylus) { %>li Stylus<% } %>
+        <% if (includeModernizr) { %>li Modernizr<% } %>
+        <% if (includejQuery) { %>li jQuery<% } %>
+        <% if (includeCoffeeScript) { %>li CoffeeScript<% } %>
+    <% } %>
+    // build:js scripts/vendor.js
+    // bower:js
+    <% if (includeBootstrap || includejQuery) { %>script(src='bower_components/jquery/dist/jquery.js')<% } %>
+    <% if (includeBootstrap && (!includeSass && !includeStylus)) { %>script(src='bower_components/bootstrap/dist/js/bootstrap.min.js')<% } %>
+    <% if (includeSass && includeBootstrap) { %>script(src='bower_components/bootstrap-sass/assets/javascripts/bootstrap.min.js')<% } %>
+    <% if (includeStylus && includeBootstrap) { %>script(src='bower_components/bootstrap-stylus/js/transition.js')
+    script(src='bower_components/bootstrap-stylus/js/alert.js')
+    script(src='bower_components/bootstrap-stylus/js/button.js')
+    script(src='bower_components/bootstrap-stylus/js/carousel.js')
+    script(src='bower_components/bootstrap-stylus/js/collapse.js')
+    script(src='bower_components/bootstrap-stylus/js/dropdown.js')
+    script(src='bower_components/bootstrap-stylus/js/modal.js')
+    script(src='bower_components/bootstrap-stylus/js/tooltip.js')
+    script(src='bower_components/bootstrap-stylus/js/popover.js')
+    script(src='bower_components/bootstrap-stylus/js/scrollspy.js')
+    script(src='bower_components/bootstrap-stylus/js/tab.js')
+    script(src='bower_components/bootstrap-stylus/js/affix.js')<% } %>
+    // endbower
+    // endbuild
+    script(src='scripts/app.js')
+    // Google Analytics: change UA-XXXXX-X to be your site's ID.
+    script.
+      (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
+      function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
+      e=o.createElement(i);r=o.getElementsByTagName(i)[0];
+      e.src='//www.google-analytics.com/analytics.js';
+      r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
+      ga('create','UA-XXXXX-X');ga('send','pageview');

--- a/app/templates/main.css
+++ b/app/templates/main.css
@@ -1,4 +1,4 @@
-@import "bootstrap-sass-official/assets/stylesheets/bootstrap";
+@import "../bower_components/bootstrap/dist/css/bootstrap.min.css";
 
 .browsehappy {
   margin: 0.2em 0;

--- a/app/templates/main.css
+++ b/app/templates/main.css
@@ -1,0 +1,118 @@
+@import "bootstrap-sass-official/assets/stylesheets/bootstrap";
+
+.browsehappy {
+  margin: 0.2em 0;
+  background: #ccc;
+  color: #000;
+  padding: 0.2em 0;
+}
+
+/* Space out content a bit */
+body {
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
+/* Everything but the jumbotron gets side spacing for mobile first views */
+.header,
+.marketing,
+.footer {
+  padding-left: 15px;
+  padding-right: 15px;
+}
+
+/* Custom page header */
+.header {
+  border-bottom: 1px solid #e5e5e5;
+  /* Make the masthead heading the same height as the navigation */
+}
+
+.header h3 {
+  margin-top: 0;
+  margin-bottom: 0;
+  line-height: 40px;
+  padding-bottom: 19px;
+}
+
+/* Custom page footer */
+.footer {
+  padding-top: 19px;
+  color: #777;
+  border-top: 1px solid #e5e5e5;
+}
+
+.container-narrow > hr {
+  margin: 30px 0;
+}
+
+/* Main marketing message and sign up button */
+.jumbotron {
+  text-align: center;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.jumbotron .btn {
+  font-size: 21px;
+  padding: 14px 24px;
+}
+
+/* Supporting marketing content */
+.marketing {
+  margin: 40px 0;
+}
+
+.marketing p + h4 {
+  margin-top: 28px;
+}
+
+/* Responsive: Portrait tablets and up */
+@media screen and (min-width: 768px) {
+  .container {
+    max-width: 730px;
+  }
+  /* Remove the padding we set earlier */
+  .header,
+  .marketing,
+  .footer {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  /* Space out the masthead */
+  .header {
+    margin-bottom: 30px;
+  }
+  /* Remove the bottom border on the jumbotron for visual effect */
+  .jumbotron {
+    border-bottom: 0;
+  }
+}
+
+body {
+  background: #fafafa;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  color: #333;
+}
+
+.hero-unit {
+  margin: 50px auto 0 auto;
+  width: 300px;
+  font-size: 18px;
+  font-weight: 200;
+  line-height: 30px;
+  background-color: #eee;
+  border-radius: 6px;
+  padding: 60px;
+}
+
+.hero-unit h1 {
+  font-size: 60px;
+  line-height: 1;
+  letter-spacing: -1px;
+}
+
+.browsehappy {
+  margin: 0.2em 0;
+  background: #ccc;
+  color: #000;
+  padding: 0.2em 0;
+}

--- a/app/templates/main.css
+++ b/app/templates/main.css
@@ -1,4 +1,4 @@
-@import "../bower_components/bootstrap/dist/css/bootstrap.min.css";
+<% if (includeBootstrap) { %>@import "../bower_components/bootstrap/dist/css/bootstrap.min.css";<% } %>
 
 .browsehappy {
   margin: 0.2em 0;

--- a/app/templates/main.styl
+++ b/app/templates/main.styl
@@ -1,0 +1,115 @@
+<% if (includeBootstrap) { %>$icon-font-path = "../fonts/"
+
+@import "bootstrap-sass-official/assets/stylesheets/bootstrap"
+
+.browsehappy
+  margin  0.2em 0
+  background  #ccc
+  color #000
+  padding 0.2em 0
+
+/* Space out content a bit */
+
+body
+  padding-top 20px
+  padding-bottom 20px
+
+/* Everything but the jumbotron gets side spacing for mobile first views */
+
+.header,
+.marketing,
+.footer
+  padding-left 15px
+  padding-right 15px
+
+/* Custom page header */
+
+.header
+  border-bottom 1px solid #e5e5e5
+
+  /* Make the masthead heading the same height as the navigation */
+
+  h3
+    margin-top 0
+    margin-bottom 0
+    line-height 40px
+    padding-bottom 19px
+
+/* Custom page footer */
+
+.footer
+  padding-top 19px
+  color #777
+  border-top 1px solid #e5e5e5
+
+.container-narrow > hr
+  margin 30px 0
+
+/* Main marketing message and sign up button */
+
+.jumbotron
+  text-align center
+  border-bottom 1px solid #e5e5e5
+
+  .btn
+    font-size 21px
+    padding 14px 24px
+
+/* Supporting marketing content */
+
+.marketing
+  margin 40px 0
+
+  p + h4
+    margin-top 28px
+
+/* Responsive Portrait tablets and up */
+
+@media screen and (min-width 768px)
+
+  .container
+    max-width 730px
+
+  /* Remove the padding we set earlier */
+
+  .header,
+  .marketing,
+  .footer
+    padding-left 0
+    padding-right 0
+
+  /* Space out the masthead */
+
+  .header
+    margin-bottom 30px
+
+  /* Remove the bottom border on the jumbotron for visual effect */
+
+  .jumbotron
+    border-bottom 0
+
+<% } else { %>body
+  background #fafafa
+  font-family "Helvetica Neue", Helvetica, Arial, sans-serif
+  color #333
+
+.hero-unit
+  margin 50px auto 0 auto
+  width 300px
+  font-size 18px
+  font-weight 200
+  line-height 30px
+  background-color #eee
+  border-radius 6px
+  padding 60px
+
+  h1
+    font-size 60px
+    line-height 1
+    letter-spacing -1px
+
+.browsehappy
+  margin 0.2em 0
+  background #ccc
+  color #000
+  padding 0.2em 0<% } %>

--- a/app/templates/main.styl
+++ b/app/templates/main.styl
@@ -1,6 +1,6 @@
 <% if (includeBootstrap) { %>$icon-font-path = "../fonts/"
 
-@import "bootstrap-sass-official/assets/stylesheets/bootstrap"
+@import "../bower_components/bootstrap-stylus/bootstrap/index"
 
 .browsehappy
   margin  0.2em 0

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -3,7 +3,7 @@
 var path = require('path');
 var helpers = require('yeoman-generator').test;
 
-describe('react-gulp-browserify generator', function () {
+describe('react-gulp-browserify generator basic', function () {
   beforeEach(function (done) {
     helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
       if (err) {
@@ -25,8 +25,336 @@ describe('react-gulp-browserify generator', function () {
         'package.json',
         'gulpfile.js',
         'app/index.html',
+        'app/scripts/ui/Timer.js',
+        'app/scripts/app.js'
+    ];
+
+
+    helpers.mockPrompt(this.app, {
+        features: [
+        ]
+    });
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFile(expected);
+      done();
+    });
+  });
+});
+
+describe('react-gulp-browserify generator with Modernizr', function () {
+  beforeEach(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      this.app = helpers.createGenerator('react-gulp-browserify:app', [
+        '../../app'
+      ]);
+      done();
+    }.bind(this));
+  });
+
+  it('creates expected files', function (done) {
+    var expected = [
+        '.jshintrc',
+        '.editorconfig',
+        'bower.json',
+        'package.json',
+        'gulpfile.js',
+        'app/index.html',
+        'app/scripts/ui/Timer.js',
+        'app/scripts/app.js'
+    ];
+
+    helpers.mockPrompt(this.app, {
+        features: [
+            'includeModernizr'
+        ]
+    });
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFile(expected);
+      helpers.assertFileContent('bower.json', /modernizr/);
+      done();
+    });
+  });
+});
+
+describe('react-gulp-browserify generator with Jade', function () {
+  beforeEach(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      this.app = helpers.createGenerator('react-gulp-browserify:app', [
+        '../../app'
+      ]);
+      done();
+    }.bind(this));
+  });
+
+  it('creates expected files', function (done) {
+    var expected = [
+        '.jshintrc',
+        '.editorconfig',
+        'bower.json',
+        'package.json',
+        'gulpfile.js',
+        'app/index.jade',
+        'app/scripts/ui/Timer.js',
+        'app/scripts/app.js'
+    ];
+
+
+    helpers.mockPrompt(this.app, {
+        features: [
+            'includeJade'
+        ]
+    });
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFile(expected);
+      done();
+    });
+  });
+});
+
+describe('react-gulp-browserify generator with sass', function () {
+  beforeEach(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      this.app = helpers.createGenerator('react-gulp-browserify:app', [
+        '../../app'
+      ]);
+      done();
+    }.bind(this));
+  });
+
+  it('creates expected files', function (done) {
+    var expected = [
+        '.jshintrc',
+        '.editorconfig',
+        'bower.json',
+        'package.json',
+        'gulpfile.js',
+        'app/index.html',
+        'app/scripts/ui/Timer.js',
+        'app/scripts/app.js',
+        'app/styles/main.scss'
+    ];
+
+
+    helpers.mockPrompt(this.app, {
+        features: [
+            'includeSass'
+        ]
+    });
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFile(expected);
+      done();
+    });
+  });
+});
+
+describe('react-gulp-browserify generator with stylus', function () {
+  beforeEach(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      this.app = helpers.createGenerator('react-gulp-browserify:app', [
+        '../../app'
+      ]);
+      done();
+    }.bind(this));
+  });
+
+  it('creates expected files', function (done) {
+    var expected = [
+        '.jshintrc',
+        '.editorconfig',
+        'bower.json',
+        'package.json',
+        'gulpfile.js',
+        'app/index.html',
+        'app/scripts/ui/Timer.js',
+        'app/scripts/app.js',
+        'app/styles/main.styl'
+    ];
+
+
+    helpers.mockPrompt(this.app, {
+        features: [
+            'includeStylus'
+        ]
+    });
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFile(expected);
+      done();
+    });
+  });
+});
+
+describe('react-gulp-browserify generator with jQuery', function () {
+  beforeEach(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      this.app = helpers.createGenerator('react-gulp-browserify:app', [
+        '../../app'
+      ]);
+      done();
+    }.bind(this));
+  });
+
+  it('creates expected files', function (done) {
+    var expected = [
+        '.jshintrc',
+        '.editorconfig',
+        'bower.json',
+        'package.json',
+        'gulpfile.js',
+        'app/index.html',
+        'app/scripts/ui/Timer.js',
+        'app/scripts/app.js'
+    ];
+
+
+    helpers.mockPrompt(this.app, {
+        features: [
+            'includejQuery'
+        ]
+    });
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFile(expected);
+      helpers.assertFileContent('bower.json', /jquery/);
+      done();
+    });
+  });
+});
+
+
+describe('react-gulp-browserify generator with bootstrap', function () {
+  beforeEach(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      this.app = helpers.createGenerator('react-gulp-browserify:app', [
+        '../../app'
+      ]);
+      done();
+    }.bind(this));
+  });
+
+  it('creates expected files', function (done) {
+    var expected = [
+        '.jshintrc',
+        '.editorconfig',
+        'bower.json',
+        'package.json',
+        'gulpfile.js',
+        'app/index.html',
+        'app/scripts/ui/Timer.js',
+        'app/scripts/app.js'
+    ];
+
+
+    helpers.mockPrompt(this.app, {
+        features: [
+            'includeBootstrap'
+        ]
+    });
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFile(expected);
+      helpers.assertFileContent('bower.json', /bootstrap/);
+      helpers.assertFileContent('bower.json', /jquery/);
+      done();
+    });
+  });
+});
+
+describe('react-gulp-browserify generator with coffeescript', function () {
+  beforeEach(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      this.app = helpers.createGenerator('react-gulp-browserify:app', [
+        '../../app'
+      ]);
+      done();
+    }.bind(this));
+  });
+
+  it('creates expected files', function (done) {
+    var expected = [
+        '.jshintrc',
+        '.editorconfig',
+        'bower.json',
+        'package.json',
+        'gulpfile.js',
+        'gulpfile.coffee',
+        'app/index.html',
         'app/scripts/ui/Timer.coffee',
         'app/scripts/app.coffee'
+    ];
+
+
+    helpers.mockPrompt(this.app, {
+        features: [
+            'includeCoffeeScript'
+        ]
+    });
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFile(expected);
+      done();
+    });
+  });
+});
+
+describe('react-gulp-browserify generator with jade, modernizr, bootstrap, sass, and coffeescript', function () {
+  beforeEach(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      this.app = helpers.createGenerator('react-gulp-browserify:app', [
+        '../../app'
+      ]);
+      done();
+    }.bind(this));
+  });
+
+  it('creates expected files', function (done) {
+    var expected = [
+        '.jshintrc',
+        '.editorconfig',
+        'bower.json',
+        'package.json',
+        'gulpfile.js',
+        'gulpfile.coffee',
+        'app/index.jade',
+        'app/scripts/ui/Timer.coffee',
+        'app/scripts/app.coffee',
+        'app/styles/main.scss'
     ];
 
 
@@ -37,12 +365,65 @@ describe('react-gulp-browserify generator', function () {
             'includeModernizr',
             'includeJade',
             'includeCoffeeScript',
-            'includeStylus'
         ]
     });
     this.app.options['skip-install'] = true;
     this.app.run({}, function () {
       helpers.assertFile(expected);
+      helpers.assertFileContent('bower.json', /bootstrap/);
+      helpers.assertFileContent('bower.json', /sass/);
+      helpers.assertFileContent('bower.json', /modernizr/);
+      helpers.assertFileContent('bower.json', /jquery/);
+      done();
+    });
+  });
+});
+
+describe('react-gulp-browserify generator with jade, modernizr, bootstrap, stylus, and coffeescript', function () {
+  beforeEach(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      this.app = helpers.createGenerator('react-gulp-browserify:app', [
+        '../../app'
+      ]);
+      done();
+    }.bind(this));
+  });
+
+  it('creates expected files', function (done) {
+    var expected = [
+        '.jshintrc',
+        '.editorconfig',
+        'bower.json',
+        'package.json',
+        'gulpfile.js',
+        'gulpfile.coffee',
+        'app/index.jade',
+        'app/scripts/ui/Timer.coffee',
+        'app/scripts/app.coffee',
+        'app/styles/main.styl'
+    ];
+
+
+    helpers.mockPrompt(this.app, {
+        features: [
+            'includeStylus',
+            'includeBootstrap',
+            'includeModernizr',
+            'includeJade',
+            'includeCoffeeScript',
+        ]
+    });
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFile(expected);
+      helpers.assertFileContent('bower.json', /jquery/);
+      helpers.assertFileContent('bower.json', /modernizr/);
+      helpers.assertFileContent('bower.json', /bootstrap/);
+      helpers.assertFileContent('bower.json', /stylus/);
       done();
     });
   });

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -36,7 +36,8 @@ describe('react-gulp-browserify generator', function () {
             'includeBootstrap',
             'includeModernizr',
             'includeJade',
-            'includeCoffeeScript'
+            'includeCoffeeScript',
+            'includeStylus'
         ]
     });
     this.app.options['skip-install'] = true;


### PR DESCRIPTION
Made these changes because I wanted to use stylus but was surprised to see that even when you select stylus it still uses sass as well. This update ensures that all generator options produce the app files as expected.

* If you select sass then main.scss is added and not main.css
* If you select stylus then main.style is added and not main.css or main.scss
* If you select sass and bootstrap then the sass bootstrap will be included
* If you select stylus and bootstrap then the stylus bootstrap will be included
* If you select coffeescript then only the coffeescript files, and not JS files, will be added, also coffeescript gulpfile
* If you select jade then index.jade will be added and not index.html
* jQuery is optional but will be included if you select bootstrap as jQuery is a dependency of bootstrap