### PR TITLE
update script tag to hit bootstrap-sass-official

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -95,7 +95,7 @@
         <% if (includeBootstrap || includejQuery) { %><script src="bower_components/jquery/dist/jquery.js"></script><% } %>
         <% if (includeBootstrap && (!includeSass && !includeStylus)) { %>
         <script src="bower_components/bootstrap/dist/js/bootstrap.min.js"></script><% } %>
-        <% if (includeSass && includeBootstrap) { %><script src="bower_components/bootstrap-sass/assets/javascripts/bootstrap.min.js"></script><% } %>
+        <% if (includeSass && includeBootstrap) { %><script src="bower_components/bootstrap-sass-official/assets/javascripts/bootstrap.min.js"></script><% } %>
         <% if (includeStylus && includeBootstrap) { %><script src="bower_components/bootstrap-stylus/js/transition.js"></script>
         <script src="bower_components/bootstrap-stylus/js/alert.js"></script>
         <script src="bower_components/bootstrap-stylus/js/button.js"></script>


### PR DESCRIPTION
bootstrap found at `bower_components/bootstrap-sass-official/assets/javascripts/bootstrap.min.js` over `bootstrap-sass` path. It appears to have been updated in the jade template, but not the plain html.