### PR TITLE
Add babelify transform to use ES6

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -9,6 +9,7 @@ var path = require('path');
 
 // Load plugins
 var $ = require('gulp-load-plugins')();
+var babelify = require('babelify');
 var browserify = require('browserify');
 var watchify = require('watchify');
 var source = require('vinyl-source-stream'),
@@ -83,8 +84,9 @@ function rebundle() {
 gulp.task('scripts', rebundle);
 
 gulp.task('buildScripts', function() {
-    return browserify(sourceFile)
-        .bundle()
+  var bundler = browserify(sourceFile);
+  bundler.transform(babelify);
+  bundler.bundle()
         .pipe(source(destFileName))
         .pipe(gulp.dest('dist/scripts'));
 });

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "keywords": [
     "yeoman-generator",
     "react",
+    "babelify",
     "browserify",
     "gulp"
   ],


### PR DESCRIPTION
I'm still quite new to this gulp world so feel free to modify this PR (or send me some instructions on how to improve it). There are no tests for this change. I was able to test on one of my React JS apps and works fine, it allows using the below as an example:

```javascript
import { Router, Route, hashHistory } from 'react-router'
```