### PR TITLE
babelify instead of react-tools for jest, babelify to v7 and support …

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,24 @@ Bundled:
 
 * Gulp
 * Bower
-* jQuery
+* jQuery (optional)
 * Browserify
-* Reactify - Help to transform JSX (consider to use babelify later)
+* Reactify - (removed)
+* Babelify Help to transform JSX (consider to use babelify later)
 * Watchify support! (Sourcemap also!)
 * livereload (BrowserSync)
+* jshintrc file (although eslint is much better)
 
-Optional:
+## To be added
+* React Bootstrap instead of Sass Bootstrap
+
+Optional: and some should not be used except for compatibility
 
 * Sass with Compass
-* Bootstrap - Twitter Bootstrap's official Sass version
+* Bootstrap - Twitter Bootstrap's official Sass version 
 * Modernizr
-* Jade for HTML templates (I think jade is no longer necessary if we create UI with JavaScript)
-* CoffeeScript for JavaScript
+* Jade for HTML templates (deprecated used React JSX instead)
+* CoffeeScript for JavaScript (deprecated use React JSX instead)
 * Jest for unit tests
 
 ## Environment requirements
@@ -42,6 +47,16 @@ Optional:
 $ npm install -g yo                                # Install Yeoman (if you don't have it yet)...
 $ npm install -g generator-react-gulp-browserify   # ...then install this generator...
 $ yo react-gulp-browserify                         # ...and run it.
+```
+
+## If you are doing a fork
+Then you need to `git clone` your fork and from there use npm link. See
+http://yeoman.io/authoring/
+
+```
+git clone git@github.com/<your git repo>/generate-react-gulp-browserify
+cd generate-react-gulp-browserify
+npm link
 ```
 
 If you chose to use sass, you'll need to install it with `gem install sass`.

--- a/app/index.js
+++ b/app/index.js
@@ -44,7 +44,7 @@ var ReactGulpBrowserifyGenerator = yeoman.generators.Base.extend({
             }, {
                 name: 'jQuery',
                 value: 'includejQuery',
-                checked: true
+                checked: false
             }, {
                 name: 'Bootstrap',
                 value: 'includeBootstrap',
@@ -56,11 +56,11 @@ var ReactGulpBrowserifyGenerator = yeoman.generators.Base.extend({
             }, {
                 name: 'HTML template - Jade',
                 value: 'includeJade',
-                checked: true
+                checked: false
             }, {
                 name: 'CoffeeScript for JavaScript',
                 value: 'includeCoffeeScript',
-                checked: true
+                checked: false
             }, {
                 name: 'Jest for unit tests',
                 value: 'includeJest',

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -23,11 +23,10 @@
         "gulp-useref": "~0.4.4",
         "gulp-util": "~3.0.1",
         "gulp-webserver": "latest", <% if (includeJest) { %>
+        "babel-jest" : "latest",
         "jest-cli": "latest", <% } %>
         "react": "latest",
         "react-dom": "latest",
-        "react-tools": "latest",
-        "reactify": "latest",
         "watchify": "~2.1",
         "browserify-shim": "^3.8.0",
         "gulp-uglify": "^1.0.2",
@@ -35,7 +34,9 @@
         "gulp-strip-debug": "^1.0.2",
         "vinyl-source-stream": "^1.0.0",
         "main-bower-files": "~2.6.2",
-        "babelify": "^6.1.3"
+        "babel-preset-latest": "^6.14.0",
+        "babel-preset-react": "^6.11.1",
+        "babelify": "^7.0.0"
     },
     "engines": {
         "node": ">=0.10.0"
@@ -44,7 +45,7 @@
         "test": "jest"
     },
     "jest": {
-        "scriptPreprocessor": "<rootDir>/preprocessor.js",
+        "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
         "unmockedModulePathPatterns": [
             "<rootDir>/node_modules/react"
         ]
@@ -55,6 +56,10 @@
             "coffeeify", <% } %>
             [
                 "babelify", {
+                    "presets" : [
+                        "latest",
+                        "react"
+                    ],
                     "ignore": [
                         "bower_components"
                     ]

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -4,7 +4,7 @@
     "dependencies": {},
     "devDependencies": {
         "browserify": "latest",
-        "del": "~0.1.3",
+        "del": "^2.0.0",
         "gulp": ">=3.8.8",
         "gulp-autoprefixer": "~1.0.1",
         "gulp-bower": "0.0.6",
@@ -27,7 +27,7 @@
         "jest-cli": "latest", <% } %>
         "react": "latest",
         "react-dom": "latest",
-        "watchify": "~2.1",
+        "watchify": "latest",
         "browserify-shim": "^3.8.0",
         "gulp-uglify": "^1.0.2",
         "strip-debug": "^1.0.1",


### PR DESCRIPTION
Ok I made some changes:

1. Instead of using react-tools for jest, we use babelify. Also it looks like documentation was off, this no longer uses reactify, but it does use the obsolete babelify 6.x, so switched to 7.x.
2. Jade is not needed if you are using react for display (sort of the point of React), so made that and optional
3. Update documentation to explain what is added (for instance a jshint file).
4. This now supports ES6 with it's latest and react as well. 